### PR TITLE
Use "const std::string&" instead of "std::string". ';' moved to the right place

### DIFF
--- a/LemonUI.SHV/Elements/Font.hpp
+++ b/LemonUI.SHV/Elements/Font.hpp
@@ -27,5 +27,5 @@ namespace LemonUI::Elements
         /// Pricedown.
         /// </summary>
         Pricedown = 7
-    }
-};
+    };
+}

--- a/LemonUI.SHV/Sound.cpp
+++ b/LemonUI.SHV/Sound.cpp
@@ -4,7 +4,7 @@
 
 namespace LemonUI
 {
-	Sound::Sound(std::string set, std::string file)
+	Sound::Sound(const std::string& set, const std::string& file)
 	{
 		this->set = set;
 		this->file = file;
@@ -15,7 +15,7 @@ namespace LemonUI
 		return this->set;
 	}
 
-	void Sound::SetSet(std::string set)
+	void Sound::SetSet(const std::string& set)
 	{
 		this->set = set;
 	}
@@ -25,7 +25,7 @@ namespace LemonUI
 		return this->file;
 	}
 
-	void Sound::SetFile(std::string file)
+	void Sound::SetFile(const std::string& file)
 	{
 		this->file = file;
 	}

--- a/LemonUI.SHV/Sound.hpp
+++ b/LemonUI.SHV/Sound.hpp
@@ -10,12 +10,12 @@ namespace LemonUI
 		std::string file;
 
 	public:
-		Sound(std::string set, std::string file);
+		Sound(const std::string& set, const std::string& file);
 
 		std::string GetSet();
-		void SetSet(std::string);
+		void SetSet(const std::string&);
 		std::string GetFile();
-		void SetFile(std::string);
+		void SetFile(const std::string&);
 
 		void PlayFrontend();
 	};


### PR DESCRIPTION
With "std::string" you create a copy of the string, but we don't need it.

Here is an example that it works:
```cpp
class Sound
{
private:
  std::string set;

public:
  Sound(const std::string& set)
  {
    this->set = set;
  }

  void PlayFrontend()
  {
    std::cout << this->set;
  }
};

int main()
{
  Sound* testSound = new Sound("test 123");
  testSound->PlayFrontend();

  delete testSound;

  return 0;
}
```