### PR TITLE
Improve performance of ProcessControls

### DIFF
--- a/LemonUI/Menus/NativeMenu.cs
+++ b/LemonUI/Menus/NativeMenu.cs
@@ -99,7 +99,7 @@ namespace LemonUI.Menus
         /// <summary>
         /// The controls required by the menu with both a gamepad and mouse + keyboard.
         /// </summary>
-        internal static List<Control> controlsRequired = new List<Control>
+        internal static HashSet<Control> controlsRequired = new HashSet<Control>
         {
             // Menu Controls
             Control.FrontendAccept,
@@ -1002,6 +1002,8 @@ namespace LemonUI.Menus
             // If the user wants to disable the controls, do so but only the ones required
             if (DisableControls)
             {
+                bool isUsingController = Controls.IsUsingController;
+
                 foreach (Control control in controls)
                 {
                     // If the control is required by the menu
@@ -1010,12 +1012,12 @@ namespace LemonUI.Menus
                         continue;
                     }
                     // If the player is using a controller and is required on gamepads
-                    if (Controls.IsUsingController && controlsGamepad.Contains(control))
+                    if (isUsingController && controlsGamepad.Contains(control))
                     {
                         continue;
                     }
                     // If the player is usinng a controller or mouse usage is disabled and is a camera control
-                    if ((Controls.IsUsingController || !UseMouse) && controlsCamera.Contains(control))
+                    if ((isUsingController || !UseMouse) && controlsCamera.Contains(control))
                     {
                         continue;
                     }

--- a/LemonUI/Menus/NativeMenu.cs
+++ b/LemonUI/Menus/NativeMenu.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace LemonUI.Menus
 {
@@ -97,75 +98,6 @@ namespace LemonUI.Menus
         /// </summary>
         internal static readonly SizeF searchAreaSize = new SizeF(30, 1080);
         /// <summary>
-        /// The controls required by the menu with both a gamepad and mouse + keyboard.
-        /// </summary>
-        internal static HashSet<Control> controlsRequired = new HashSet<Control>
-        {
-            // Menu Controls
-            Control.FrontendAccept,
-            Control.FrontendAxisX,
-            Control.FrontendAxisY,
-            Control.FrontendDown,
-            Control.FrontendUp,
-            Control.FrontendLeft,
-            Control.FrontendRight,
-            Control.FrontendCancel,
-            Control.FrontendSelect,
-            Control.CursorScrollDown,
-            Control.CursorScrollUp,
-            Control.CursorX,
-            Control.CursorY,
-            Control.MoveUpDown,
-            Control.MoveLeftRight,
-            // Camera
-            Control.LookBehind,
-            Control.VehicleLookBehind,
-            // Player
-            Control.Sprint,
-            Control.Jump,
-            Control.Enter,
-            Control.SpecialAbility,
-            Control.SpecialAbilityPC,
-            Control.SpecialAbilitySecondary,
-            Control.VehicleSpecialAbilityFranklin,
-            // Driving
-            Control.VehicleExit,
-            Control.VehicleAccelerate,
-            Control.VehicleBrake,
-            Control.VehicleMoveLeftRight,
-            Control.VehicleHandbrake,
-            Control.VehicleHorn,
-            // Bikes
-            Control.VehiclePushbikePedal,
-            Control.VehiclePushbikeSprint,
-            Control.VehiclePushbikeFrontBrake,
-            Control.VehiclePushbikeRearBrake,
-            // Flying
-            Control.VehicleFlyThrottleUp,
-            Control.VehicleFlyThrottleDown,
-            Control.VehicleFlyYawLeft,
-            Control.VehicleFlyYawRight,
-            Control.VehicleFlyRollLeftRight,
-            Control.VehicleFlyRollLeftOnly,
-            Control.VehicleFlyRollRightOnly,
-            Control.VehicleFlyPitchUpDown,
-            Control.VehicleFlyPitchUpOnly,
-            Control.VehicleFlyPitchDownOnly,
-#if RPH
-            Control.ScriptedFlyUpDown,
-            Control.ScriptedFlyLeftRight,
-#else
-            Control.FlyUpDown,
-            Control.FlyLeftRight,
-#endif
-            // Rockstar Editor
-            Control.SaveReplayClip,
-            Control.ReplayStartStopRecording,
-            Control.ReplayStartStopRecordingSecondary,
-            Control.ReplayRecord,
-            Control.ReplaySave,
-        };
-        /// <summary>
         /// Controls required for the camera to work.
         /// </summary>
         internal static readonly List<Control> controlsCamera = new List<Control>
@@ -183,9 +115,9 @@ namespace LemonUI.Menus
         };
 
         /// <summary>
-        /// A list of GTA V Controls.
+        /// A list of GTA V Controls that are not required by the menu with both a gamepad and mouse + keyboard.
         /// </summary>
-        private static readonly Control[] controls = (Control[])Enum.GetValues(typeof(Control));
+        private static readonly Control[] controls;
         /// <summary>
         /// If the menu has just been opened and we should check the controls.
         /// </summary>
@@ -741,6 +673,79 @@ namespace LemonUI.Menus
 
         #region Constructors
 
+        static NativeMenu()
+        {
+            // The controls required by the menu with both a gamepad and mouse + keyboard
+            HashSet<Control> controlsRequired = new HashSet<Control>
+            {
+                // Menu Controls
+                Control.FrontendAccept,
+                Control.FrontendAxisX,
+                Control.FrontendAxisY,
+                Control.FrontendDown,
+                Control.FrontendUp,
+                Control.FrontendLeft,
+                Control.FrontendRight,
+                Control.FrontendCancel,
+                Control.FrontendSelect,
+                Control.CursorScrollDown,
+                Control.CursorScrollUp,
+                Control.CursorX,
+                Control.CursorY,
+                Control.MoveUpDown,
+                Control.MoveLeftRight,
+                // Camera
+                Control.LookBehind,
+                Control.VehicleLookBehind,
+                // Player
+                Control.Sprint,
+                Control.Jump,
+                Control.Enter,
+                Control.SpecialAbility,
+                Control.SpecialAbilityPC,
+                Control.SpecialAbilitySecondary,
+                Control.VehicleSpecialAbilityFranklin,
+                // Driving
+                Control.VehicleExit,
+                Control.VehicleAccelerate,
+                Control.VehicleBrake,
+                Control.VehicleMoveLeftRight,
+                Control.VehicleHandbrake,
+                Control.VehicleHorn,
+                // Bikes
+                Control.VehiclePushbikePedal,
+                Control.VehiclePushbikeSprint,
+                Control.VehiclePushbikeFrontBrake,
+                Control.VehiclePushbikeRearBrake,
+                // Flying
+                Control.VehicleFlyThrottleUp,
+                Control.VehicleFlyThrottleDown,
+                Control.VehicleFlyYawLeft,
+                Control.VehicleFlyYawRight,
+                Control.VehicleFlyRollLeftRight,
+                Control.VehicleFlyRollLeftOnly,
+                Control.VehicleFlyRollRightOnly,
+                Control.VehicleFlyPitchUpDown,
+                Control.VehicleFlyPitchUpOnly,
+                Control.VehicleFlyPitchDownOnly,
+#if RPH
+                Control.ScriptedFlyUpDown,
+                Control.ScriptedFlyLeftRight,
+#else
+                Control.FlyUpDown,
+                Control.FlyLeftRight,
+#endif
+                // Rockstar Editor
+                Control.SaveReplayClip,
+                Control.ReplayStartStopRecording,
+                Control.ReplayStartStopRecordingSecondary,
+                Control.ReplayRecord,
+                Control.ReplaySave,
+            };
+
+            controls = ((Control[])Enum.GetValues(typeof(Control))).Except(controlsRequired).ToArray();
+        }
+
         /// <summary>
         /// Creates a new menu with the specified title.
         /// </summary>
@@ -1006,11 +1011,6 @@ namespace LemonUI.Menus
 
                 foreach (Control control in controls)
                 {
-                    // If the control is required by the menu
-                    if (controlsRequired.Contains(control))
-                    {
-                        continue;
-                    }
                     // If the player is using a controller and is required on gamepads
                     if (isUsingController && controlsGamepad.Contains(control))
                     {

--- a/LemonUI/Scaleform/BaseScaleform.cs
+++ b/LemonUI/Scaleform/BaseScaleform.cs
@@ -364,7 +364,9 @@ namespace LemonUI.Scaleform
 #elif RPH
             NativeFunction.CallByHash<int>(0x1D132D614DD86811, new NativeArgument(id));
 #elif SHVDN3
-            Function.Call(Hash.SET_SCALEFORM_MOVIE_AS_NO_LONGER_NEEDED, new OutputArgument(id));
+            OutputArgument idPtr = new OutputArgument(id);
+            Function.Call(Hash.SET_SCALEFORM_MOVIE_AS_NO_LONGER_NEEDED, idPtr);
+            idPtr.Dispose();
 #endif
         }
 

--- a/LemonUI/Scaleform/BaseScaleform.cs
+++ b/LemonUI/Scaleform/BaseScaleform.cs
@@ -364,9 +364,10 @@ namespace LemonUI.Scaleform
 #elif RPH
             NativeFunction.CallByHash<int>(0x1D132D614DD86811, new NativeArgument(id));
 #elif SHVDN3
-            OutputArgument idPtr = new OutputArgument(id);
-            Function.Call(Hash.SET_SCALEFORM_MOVIE_AS_NO_LONGER_NEEDED, idPtr);
-            idPtr.Dispose();
+            using (OutputArgument idPtr = new OutputArgument(id))
+            {
+                Function.Call(Hash.SET_SCALEFORM_MOVIE_AS_NO_LONGER_NEEDED, idPtr);
+            }
 #endif
         }
 

--- a/LemonUI/Screen.cs
+++ b/LemonUI/Screen.cs
@@ -176,6 +176,8 @@ namespace LemonUI
             Function.Call((Hash)0x6DD8F5AA635EB4B2, relativeX, relativeY, argX, argY); // _GET_SCRIPT_GFX_POSITION
             realX = argX.GetResult<float>();
             realY = argY.GetResult<float>();
+            argX.Dispose();
+            argY.Dispose();
 #endif
             // And return it converted to absolute
             ToAbsolute(realX, realY, out float absoluteX, out float absoluteY);

--- a/LemonUI/Screen.cs
+++ b/LemonUI/Screen.cs
@@ -171,13 +171,13 @@ namespace LemonUI
                 realY = argY.GetValue<float>();
             }
 #elif SHVDN3
-            OutputArgument argX = new OutputArgument();
-            OutputArgument argY = new OutputArgument();
-            Function.Call((Hash)0x6DD8F5AA635EB4B2, relativeX, relativeY, argX, argY); // _GET_SCRIPT_GFX_POSITION
-            realX = argX.GetResult<float>();
-            realY = argY.GetResult<float>();
-            argX.Dispose();
-            argY.Dispose();
+            using (OutputArgument argX = new OutputArgument())
+            using (OutputArgument argY = new OutputArgument())
+            {
+                Function.Call((Hash)0x6DD8F5AA635EB4B2, relativeX, relativeY, argX, argY); // _GET_SCRIPT_GFX_POSITION
+                realX = argX.GetResult<float>();
+                realY = argY.GetResult<float>();
+            }
 #endif
             // And return it converted to absolute
             ToAbsolute(realX, realY, out float absoluteX, out float absoluteY);


### PR DESCRIPTION
*Uh, a ~Helmet~ Performance Inspection Officer.*

When checking if some collections that has about 10 or more elements contains some other elememts, HashSet does the job fast (arrays or array lists would search faster if there are only like 2 elements). And get rid of redundant `Controls.IsUsingController` calls from the `if (DisableControls)` block since the result won't be changed and native calls are relatively expensive even without thread switching that was happened in SHVDN.
Also explicitly call `Dispose` on `OutputArgument` so the finalizer won't be called.

If you don't mind using unsafe blocks, we could get rid of the use of `OutputArgument` so no dynamic heap allocation won't happen just for 4 byte values.