### PR TITLE
Fix BaseScaleform.Dispose not using pointer value in RPH and RageMP

### DIFF
--- a/LemonUI/Scaleform/BaseScaleform.cs
+++ b/LemonUI/Scaleform/BaseScaleform.cs
@@ -360,9 +360,14 @@ namespace LemonUI.Scaleform
 #if FIVEM
             API.SetScaleformMovieAsNoLongerNeeded(ref id);
 #elif RAGEMP
-            Invoker.Invoke(Natives.SetScaleformMovieAsNoLongerNeeded, id);
+            IntReference idPtr = new IntReference(id);
+            Invoker.Invoke(Natives.SetScaleformMovieAsNoLongerNeeded, idPtr);
 #elif RPH
-            NativeFunction.CallByHash<int>(0x1D132D614DD86811, new NativeArgument(id));
+            using (NativePointer idPtr = new NativePointer(4))
+            {
+                idPtr.SetValue(id);
+                NativeFunction.CallByHash<int>(0x6DD8F5AA635EB4B2, idPtr);
+            }
 #elif SHVDN3
             Function.Call(Hash.SET_SCALEFORM_MOVIE_AS_NO_LONGER_NEEDED, new OutputArgument(id));
 #endif

--- a/LemonUI/Screen.cs
+++ b/LemonUI/Screen.cs
@@ -163,8 +163,8 @@ namespace LemonUI
             realX = argX.Value;
             realY = argY.Value;
 #elif RPH
-            using (NativePointer argX = new NativePointer())
-            using (NativePointer argY = new NativePointer())
+            using (NativePointer argX = new NativePointer(4))
+            using (NativePointer argY = new NativePointer(4))
             {
                 NativeFunction.CallByHash<int>(0x6DD8F5AA635EB4B2, relativeX, relativeY, argX, argY);
                 realX = argX.GetValue<float>();


### PR DESCRIPTION
I don't mess with the game using RPH plugins that much and I had never tried playing RageMP, but this was not that hard to catch.

By the way, `NativePointer` of RPH allocates 128 bytes in the constructor with no parameters. You can confirm by dumping `nethelper.dll` or `rockstarupdater.dll` that are created after having RPH loaded and analyze them with ILSpy.